### PR TITLE
質問用PR

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,7 @@ html
     meta http-equiv="content-type" charset="utf-8"
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
-    <script data-ad-client="ca-pub-4980696507962861" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+    / <script data-ad-client="ca-pub-4980696507962861" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
     - if Rails.env.production?
       = render 'layouts/google_analytics'


### PR DESCRIPTION
### 質問内容・実現したいこと
- 本番環境でBootStrapのJSを動かしたい

### 現状発生している問題・エラーメッセージ
- 開発環境ではドロップダウンが正常に動くが、本番環境ではドロップダウンが動かない。
- 表面的に見えるエラーは発生していない。（Chromeのディベロッパーツール上 ）
（Chromeのディベロッパーツール上で発生しているUncaughtエラーはGoogleAdsenseのものなので今回は関係ないです。）

開発環境
[![Image from Gyazo](https://i.gyazo.com/616371fda10b7121da7ee18011af132c.gif)](https://gyazo.com/616371fda10b7121da7ee18011af132c)

本番環境
https://min-kakeibo.work/
sample@example.com
password
で入れます。

※BootStrapのdropdownボタンが反応しない
（※TailwindCSSフレームワークを使用しているが、そちらで指定したbreakpointも反映していない)
[![Image from Gyazo](https://i.gyazo.com/87a16f0e6d2d1c0cdc996c4f71698783.gif)](https://gyazo.com/87a16f0e6d2d1c0cdc996c4f71698783)

### 該当のソースコード

```
# application.html.slim
doctype html
html
  head
    = display_meta_tags(default_meta_tags)
    = csrf_meta_tags
    = csp_meta_tag
    meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui"
    meta http-equiv="content-type" charset="utf-8"
    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
(略)
```

ディレクトリ階層
 アセットパイプラインではなく、webpackerを使っています。
[![Image from Gyazo](https://i.gyazo.com/bee10d8fad3f85a5cf75b540beb9d8e9.png)](https://gyazo.com/bee10d8fad3f85a5cf75b540beb9d8e9)

```
#app/javascript/packs.js
// このエントリーポイントから、JS,CSSを読み込む import->JS&CSSの読み込み

// JS----------------------
require("@rails/ujs").start()
require("turbolinks").start()
require("@rails/activestorage").start()
require("channels")

// yarn経由でインストールしたもの
require("jquery")
require("@nathanvda/cocoon")
require("bootstrap")
require("chartkick").use(require("highcharts"))
require("toastr")
// fontawesomeはJS版を使用
import '@fortawesome/fontawesome-free/js/all';

// 自前のJS
require ('message_counter.js')

//画像読み込み用
const images = require.context('../images', true)
const imagePath = (name) => images(name, true)

// CSS----------------------
import '../stylesheets/application.scss';
import '../css/tailwind.scss';

window.toastr = require('toastr')
window.jQuery = window.$ = require('jquery')

toastr.options = {
  "closeButton": true
}
```
```
#app/javascript/stylesheets/application.scss
 *= require_tree .
 *= require_self
 */

@import 'main';
@import "~bootstrap/scss/bootstrap";
@import 'over-bootstrap';
@import '~toastr/toastr';
```
Capistranoを使用し、自動デプロイしています。

```
# ターミナル
~/workspace/min-kakeibo fix_rspec* 1m 45s
❯ bundle exec cap production deploy
00:00 deploy:upload
      01 sudo mkdir -p /var/www/min-kakeibo/shared/config
    ✔ 01 sari@18.182.145.135 0.124s
      02 sudo chown -R sari.sari /var/www/min-kakeibo
    ✔ 02 sari@18.182.145.135 5.527s
      03 sudo mkdir -p /etc/nginx/sites-enabled
    ✔ 03 sari@18.182.145.135 0.099s
      04 sudo mkdir -p /etc/nginx/sites-available
    ✔ 04 sari@18.182.145.135 0.118s
      Uploading config/database.yml 100.0%
      Uploading config/master.key 100.0%
00:06 git:wrapper
      01 mkdir -p /tmp
    ✔ 01 sari@18.182.145.135 0.088s
      Uploading /tmp/git-ssh-13792485de13b387b37f.sh 100.0%
      02 chmod 700 /tmp/git-ssh-13792485de13b387b37f.sh
    ✔ 02 sari@18.182.145.135 0.094s
00:06 git:check
      01 git ls-remote git@github.com:Riri0000/min-kakeibo.git HEAD
      01 617da1609faf92ce39b0a7c81b2f467807bc4613       HEAD
    ✔ 01 sari@18.182.145.135 2.399s
00:08 deploy:check:directories
      01 mkdir -p /var/www/min-kakeibo/shared /var/www/min-kakeibo/releases
    ✔ 01 sari@18.182.145.135 0.044s
00:09 deploy:check:linked_dirs
      01 mkdir -p /var/www/min-kakeibo/shared/log /var/www/min-kakeibo/shared/tmp/pids /var/www/min-kakeibo/shared/tmp/cache /var/www/min-kake…
    ✔ 01 sari@18.182.145.135 0.086s
00:09 deploy:check:make_linked_dirs
      01 mkdir -p /var/www/min-kakeibo/shared/config
    ✔ 01 sari@18.182.145.135 0.088s
00:09 puma:nginx_config
      Uploading /tmp/nginx_min-kakeibo_production 100.0%
      01 sudo mv /tmp/nginx_min-kakeibo_production /etc/nginx/sites-available/min-kakeibo_production
    ✔ 01 sari@18.182.145.135 0.101s
      02 sudo ln -fs /etc/nginx/sites-available/min-kakeibo_production /etc/nginx/sites-enabled/min-kakeibo_production
    ✔ 02 sari@18.182.145.135 0.101s
00:10 git:clone
      The repository mirror is at /var/www/min-kakeibo/repo
00:10 git:update
      01 git remote set-url origin git@github.com:Riri0000/min-kakeibo.git
    ✔ 01 sari@18.182.145.135 0.094s
      02 git remote update --prune
      02 Fetching origin
    ✔ 02 sari@18.182.145.135 2.422s
00:12 git:create_release
      01 mkdir -p /var/www/min-kakeibo/releases/20210122103446
    ✔ 01 sari@18.182.145.135 0.090s
      02 git archive main | /usr/bin/env tar -x -f - -C /var/www/min-kakeibo/releases/20210122103446
    ✔ 02 sari@18.182.145.135 0.186s
00:13 deploy:set_current_revision
      01 echo "617da1609faf92ce39b0a7c81b2f467807bc4613" > REVISION
    ✔ 01 sari@18.182.145.135 0.090s
00:13 deploy:symlink:linked_files
      01 mkdir -p /var/www/min-kakeibo/releases/20210122103446/config
    ✔ 01 sari@18.182.145.135 0.109s
      02 ln -s /var/www/min-kakeibo/shared/config/master.key /var/www/min-kakeibo/releases/20210122103446/config/master.key
    ✔ 02 sari@18.182.145.135 0.089s
      03 rm /var/www/min-kakeibo/releases/20210122103446/config/database.yml
    ✔ 03 sari@18.182.145.135 0.096s
      04 ln -s /var/www/min-kakeibo/shared/config/database.yml /var/www/min-kakeibo/releases/20210122103446/config/database.yml
    ✔ 04 sari@18.182.145.135 0.086s
00:14 deploy:symlink:linked_dirs
      01 mkdir -p /var/www/min-kakeibo/releases/20210122103446 /var/www/min-kakeibo/releases/20210122103446/tmp /var/www/min-kakeibo/releases/…
    ✔ 01 sari@18.182.145.135 0.087s
      02 rm -rf /var/www/min-kakeibo/releases/20210122103446/log
    ✔ 02 sari@18.182.145.135 0.090s
      03 ln -s /var/www/min-kakeibo/shared/log /var/www/min-kakeibo/releases/20210122103446/log
    ✔ 03 sari@18.182.145.135 0.090s
      04 rm -rf /var/www/min-kakeibo/releases/20210122103446/tmp/pids
    ✔ 04 sari@18.182.145.135 0.087s
      05 ln -s /var/www/min-kakeibo/shared/tmp/pids /var/www/min-kakeibo/releases/20210122103446/tmp/pids
    ✔ 05 sari@18.182.145.135 0.070s
      06 ln -s /var/www/min-kakeibo/shared/tmp/cache /var/www/min-kakeibo/releases/20210122103446/tmp/cache
    ✔ 06 sari@18.182.145.135 0.091s
      07 rm -rf /var/www/min-kakeibo/releases/20210122103446/tmp/sockets
    ✔ 07 sari@18.182.145.135 0.089s
      08 ln -s /var/www/min-kakeibo/shared/tmp/sockets /var/www/min-kakeibo/releases/20210122103446/tmp/sockets
    ✔ 08 sari@18.182.145.135 0.097s
      09 ln -s /var/www/min-kakeibo/shared/public/system /var/www/min-kakeibo/releases/20210122103446/public/system
    ✔ 09 sari@18.182.145.135 0.093s
      10 ln -s /var/www/min-kakeibo/shared/vendor/bundle /var/www/min-kakeibo/releases/20210122103446/vendor/bundle
    ✔ 10 sari@18.182.145.135 0.092s
      11 ln -s /var/www/min-kakeibo/shared/public/assets /var/www/min-kakeibo/releases/20210122103446/public/assets
    ✔ 11 sari@18.182.145.135 0.093s
00:16 bundler:config
      01 $HOME/.rbenv/bin/rbenv exec bundle config --local deployment true
    ✔ 01 sari@18.182.145.135 0.445s
      02 $HOME/.rbenv/bin/rbenv exec bundle config --local path /var/www/min-kakeibo/shared/bundle
    ✔ 02 sari@18.182.145.135 0.286s
      03 $HOME/.rbenv/bin/rbenv exec bundle config --local without development:test
    ✔ 03 sari@18.182.145.135 0.274s
00:18 bundler:install
      The Gemfile's dependencies are satisfied, skipping installation
00:18 yarn:install
      01 yarn install --production
      01 yarn install v1.22.5
      01 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix packag…
      01 [1/4] Resolving packages...
      01 [2/4] Fetching packages...
      01 info fsevents@2.1.3: The platform "linux" is incompatible with this module.
      01 info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 info fsevents@1.2.13: The platform "linux" is incompatible with this module.
      01 info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 [3/4] Linking dependencies...
      01 warning " > webpack-dev-server@3.11.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
      01 warning "webpack-dev-server > webpack-dev-middleware@3.7.2" has unmet peer dependency "webpack@^4.0.0".
      01 [4/4] Building fresh packages...
      01 Done in 14.47s.
    ✔ 01 sari@18.182.145.135 15.097s
00:33 deploy:assets:precompile
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake assets:precompile
      01 yarn install v1.22.5
      01 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix packag…
      01 [1/4] Resolving packages...
      01 [2/4] Fetching packages...
      01 info fsevents@2.1.3: The platform "linux" is incompatible with this module.
      01 info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 info fsevents@1.2.13: The platform "linux" is incompatible with this module.
      01 info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 [3/4] Linking dependencies...
      01 warning " > webpack-dev-server@3.11.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
      01 warning "webpack-dev-server > webpack-dev-middleware@3.7.2" has unmet peer dependency "webpack@^4.0.0".
      01 [4/4] Building fresh packages...
      01 Done in 5.46s.
      01 yarn install v1.22.5
      01 warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix packag…
      01 [1/4] Resolving packages...
      01 [2/4] Fetching packages...
      01 info fsevents@2.1.3: The platform "linux" is incompatible with this module.
      01 info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 info fsevents@1.2.13: The platform "linux" is incompatible with this module.
      01 info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
      01 [3/4] Linking dependencies...
      01 warning " > webpack-dev-server@3.11.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
      01 warning "webpack-dev-server > webpack-dev-middleware@3.7.2" has unmet peer dependency "webpack@^4.0.0".
      01 [4/4] Building fresh packages...
      01 Done in 4.82s.
      01 Compiling...
      01 Compiled all packs in /var/www/min-kakeibo/releases/20210122103446/public/packs
      01 Hash: 1afe96ada9a7e86e1b32
      01 Version: webpack 4.44.2
      01 Time: 61980ms
      01 Built at: 01/22/2021 10:36:28 AM
      01                                                            Asset       Size  Chunks                                Chunk Names
      01                                     css/application-6f08ee07.css   26.8 KiB       0  [emitted] [immutable]         application
      01                                  css/application-6f08ee07.css.br   4.97 KiB          [emitted]
      01                                  css/application-6f08ee07.css.gz   5.73 KiB          [emitted]
      01                           js/application-4d2044027cf1ff1cf3fd.js   1.78 MiB       0  [emitted] [immutable]  [big]  application
      01               js/application-4d2044027cf1ff1cf3fd.js.LICENSE.txt   2.33 KiB          [emitted]
      01                        js/application-4d2044027cf1ff1cf3fd.js.br    512 KiB          [emitted]              [big]
      01                        js/application-4d2044027cf1ff1cf3fd.js.gz    635 KiB          [emitted]              [big]
      01                       js/application-4d2044027cf1ff1cf3fd.js.map   3.74 MiB       0  [emitted] [dev]               application
      01                    js/application-4d2044027cf1ff1cf3fd.js.map.br    871 KiB          [emitted]              [big]
      01                    js/application-4d2044027cf1ff1cf3fd.js.map.gz   1.14 MiB          [emitted]              [big]
      01                                                    manifest.json   1.09 KiB          [emitted]
      01                                                 manifest.json.br  340 bytes          [emitted]
      01                                                 manifest.json.gz  386 bytes          [emitted]
      01    media/images/kakeibo_cat-e2e1721986979396a52c8d95c13c931a.png     69 KiB          [emitted]
      01           media/images/logo-b61466040fbd954d71a7c0c2ba255286.png   85.2 KiB          [emitted]
      01 media/images/logo-no-border-930448fdaa778611c411729c762e6d8a.png   67.3 KiB          [emitted]
      01       media/images/ogp-logo-4387f500fe6b78c6416c2d3bcb4bd024.png   73.5 KiB          [emitted]
      01     media/images/title-logo-f936bf5ca7a1103722c2ae584bc13d92.png     82 KiB          [emitted]
      01     media/images/top-mobile-cba710537614e49c063431bc10ed84d9.png    125 KiB          [emitted]
      01 Entrypoint application [big] = css/application-6f08ee07.css js/application-4d2044027cf1ff1cf3fd.js js/application-4d2044027cf1ff1cf3f…
      01  [27] (webpack)/buildin/module.js 552 bytes {0} [built]
      01  [28] (webpack)/buildin/global.js 905 bytes {0} [built]
      01  [76] ./app/javascript/images/kakeibo_cat.png 107 bytes {0} [optional] [built]
      01  [77] ./app/javascript/images/logo.png 100 bytes {0} [optional] [built]
      01  [78] ./app/javascript/images/logo-no-border.png 110 bytes {0} [optional] [built]
      01  [79] ./app/javascript/images/ogp-logo.png 104 bytes {0} [optional] [built]
      01  [80] ./app/javascript/images/title-logo.png 106 bytes {0} [optional] [built]
      01  [81] ./app/javascript/images/top-mobile.png 106 bytes {0} [optional] [built]
      01  [82] ./app/javascript/packs/application.js 1.15 KiB {0} [built]
      01 [122] ./app/javascript/channels/index.js 205 bytes {0} [built]
      01 [123] ./app/javascript/channels sync _channel\.js$ 160 bytes {0} [built]
      01 [133] ./app/javascript/message_counter.js 169 bytes {0} [built]
      01 [134] ./app/javascript/images sync ^\.\/.*$ 382 bytes {0} [built]
      01 [135] ./app/javascript/stylesheets/application.scss 39 bytes {0} [built]
      01 [136] ./app/javascript/css/tailwind.scss 39 bytes {0} [built]
      01     + 124 hidden modules
      01
      01 WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
      01 This can impact web performance.
      01 Assets:
      01   js/application-4d2044027cf1ff1cf3fd.js (1.78 MiB)
      01   js/application-4d2044027cf1ff1cf3fd.js.gz (635 KiB)
      01   js/application-4d2044027cf1ff1cf3fd.js.map.gz (1.14 MiB)
      01   js/application-4d2044027cf1ff1cf3fd.js.br (512 KiB)
      01   js/application-4d2044027cf1ff1cf3fd.js.map.br (871 KiB)
      01
      01 WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can i…
      01 Entrypoints:
      01   application (1.8 MiB)
      01       css/application-6f08ee07.css
      01       js/application-4d2044027cf1ff1cf3fd.js
      01
      01
      01 WARNING in webpack performance recommendations:
      01 You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
      01 For more info visit https://webpack.js.org/guides/code-splitting/
      01 Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--7-1!node_modules/postcss-loader/src/index.js??ref--7-2!node_m…
      01     Entrypoint mini-css-extract-plugin = *
      01     [0] ./node_modules/css-loader/dist/cjs.js??ref--7-1!./node_modules/postcss-loader/src??ref--7-2!./node_modules/sass-loader/dist/c…
      01         + 1 hidden module
      01 Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--7-1!node_modules/postcss-loader/src/index.js??ref--7-2!node_m…
      01     Entrypoint mini-css-extract-plugin = *
      01     [0] ./node_modules/css-loader/dist/cjs.js??ref--7-1!./node_modules/postcss-loader/src??ref--7-2!./node_modules/sass-loader/dist/c…
      01         + 1 hidden module
      01
    ✔ 01 sari@18.182.145.135 79.406s
01:52 deploy:assets:backup_manifest
      01 mkdir -p /var/www/min-kakeibo/releases/20210122103446/assets_manifest_backup
    ✔ 01 sari@18.182.145.135 0.095s
      02 cp /var/www/min-kakeibo/releases/20210122103446/public/assets/.sprockets-manifest-212ffc3c5bfb97447ad3d6f327e59157.json /var/www/min-…
    ✔ 02 sari@18.182.145.135 0.095s
01:53 deploy:db_create
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:create
      01 Database 'Sharing_Kakeibo_production' already exists
    ✔ 01 sari@18.182.145.135 3.232s
01:56 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
```

### エラーから考えられる原因
- BootStrapだけでなく、Toastr(フラッシュメッセージ)のCSSも適用されていない＆TailwindCSSフレームワークのbreakpointも適用されていないことから、webpacker周りだと思いますが、表面的なエラーが出ていないので原因が特定できません。

### 試したこと
- AWSを使用しているので、EC2の再起動→変化なし
- 自作のJSは動いている。(いいねボタン＆`message_counter.js`)ので,jQuery自体は使用できている。
- tubolinksのせいでJSが動いていないかと思い、turbolinksを`yarn remove`して無効化したが、変化なし。
#99

- `config/environments/production.rb`内の以下の設定をtrueに変更したが、変化なし
```
  # Disable serving static files from the `/public` folder by default since
  # Apache or NGINX already handles this.
  config.public_file_server.enabled = true
```
- コンパイルができていない？と思いましたが、上記Capistranoで、`00:33 deploy:assets:precompile`コンパイルしています。

### 参考にしたURL
こちらを参考にBootStrapをインストール
https://techracho.bpsinc.jp/hachi8833/2019_11_28/83678