### PR TITLE
質問用PR(TwitterOGPについて)

### DIFF
--- a/app/views/account_books/show.html.slim
+++ b/app/views/account_books/show.html.slim
@@ -50,6 +50,7 @@
           = link_to t('defaults.edit_account_book'), edit_account_book_path(@account_book), class: 'light-square-button mt-5'
     / プロフィール部分
     .p-0.sm:p-12.w-full.sm:w-1/2.flex.flex-col.items-start.mt-5.text-base.justify-center
+      / Twitterシェア部分
       .flex.flex-col.px-4
         = link_to "https://twitter.com/share?url=https://min-kakeibo.work/dashboards/#{@account_book.id}&hashtags=みんなの家計簿,家計簿公開&lang=ja", title: 'Twitter' do
           button.relative.mt-6.w-full.blue-square-button


### PR DESCRIPTION
### 質問内容・実現したいこと
- Twitter上で、設定したOGP用の画像を表示する方法

### 現状発生している問題・エラーメッセージ
twitter上でシェアする画像は生成されているのですが、いざシェアしようとすると、デフォルトの画像が表示されてしまいます。`meta-tag`で指定した画像をシェアしたいです。


### どの処理までうまく動いているのか

OGPチェックブックレットというツールを使って、そのページのOGPを確認しました。
https://sinap.jp/blog/2012/05/ogp.html
画像は生成されています。
<img width="1026" alt="Twitter_ogp" src="https://user-images.githubusercontent.com/67212652/105654459-66d87580-5f01-11eb-8125-19fc8d71e5b1.png">

### 該当のソースコード
②Twitter OGPについて
`gem 'meta-tag'`を使用しているので、デフォルトの設定を`application_helper.rb`に定義しています。

```
#application_helper.rb
module ApplicationHelper
  def default_meta_tags
    {
      site: 'みんなの家計簿',
      title: '',
      description: 'みんなの家計簿は、家計簿公開アプリです！あなたの家計簿を公開、みんなの家計簿を見ることができるサービスです。やりくり上手な人の家計簿を参考にしたり、自分のお金の遣い方を見直すきっかけに。',
      charset: 'utf-8',
      keywords: '家計簿 家計簿公開 みんなの家計簿 家計簿のぞき見 資産公開',
      canonical: 'https://min-kakeibo.work',
      separator: '|',
      reverse: true,
      icon: [
        { href: asset_pack_url('media/images/kakeibo_cat.png'), sizes: '32x32', type: 'image/png' },
        { href: asset_pack_url('media/images/logo-no-border.png'), rel: 'apple-touch-icon-precomposed', sizes: '180x180', type: 'image/png' }
      ],
      og: {
        site_name: :site,
        title: :title,
        description: :description,
        type: 'website',
        url: :canonical,
        image: asset_pack_url('media/images/ogp-logo.png'),
        locale: 'ja_JP'
      },
      twitter: {
        card: 'summary_large_image',
        site: '@min_kakeibo'
      }
    }
  end
```
シェアしたいOGP部分
```
# views/account_books/show.html.erb

- set_meta_tags title: "{@account_book.user.nickname}さんの家計簿公開中！",
                og: {image: "https://res.cloudinary.com/#{Rails.application.credentials.cloudinary[:cloud_name]}/image/upload/l_text:Sawarabi%20Gothic_60_bold:#{@sum_of_expenditure}円,y_0,x_-130,co_rgb:545454/l_text:Sawarabi%20Gothic_30_bold:#{@account_book.user.nickname}さん,y_-150,x_170,co_rgb:545454/v1610963859/twitter-ogp_pmvwe8.png",
                      url: "https://min-kakeibo.work/dashboards/#{@account_book.id}"}
(略)

      / Twitterシェア部分
      .flex.flex-col.px-4
        = link_to "https://twitter.com/share?url=https://min-kakeibo.work/dashboards/#{@account_book.id}&hashtags=みんなの家計簿,家計簿公開&lang=ja", title: 'Twitter' do
          button.relative.mt-6.w-full.blue-square-button
            span.absolute.left-0.top-0.flex.items-center.justify-center.h-full.w-10.text-blue-500
              i.fab.fa-twitter
            span.ml-2 TwitterでSHARE
```

### 試したこと
- まず、画像URLが誤っていることを疑い、正常な画像URL(本番環境でアイコンに使用しているもの)をOGPのimageに指定して、シェア機能を試しました。しかし、これも同様にシェアする段階になると、デフォルトの画像が表示されてしまいます。

- Twitter社のcard-validatorを使用してみましたが、やはりデフォルトの画像が表示されてしまいます。
<img width="802" alt="card-validator" src="https://user-images.githubusercontent.com/67212652/105654793-16ade300-5f02-11eb-953a-4e4fdc704eee.png">

### エラーから考えられる原因
以上の結果から、画像URLの問題ではなく、`meta-tag`部分が怪しいと思いますが、これ以上問題の切り分け方が分からなかったです。

### 参考にしたURL
cloudinary と meta-tagの設定
https://qiita.com/yuppymam/items/21a65d32fed9d7ecceba
https://pote-chil.com/ruby_ogp/


meta-tag公式
https://github.com/kpumuk/meta-tags
