### PR TITLE
Account_booksコントローラーとCI用のdatabase.yamlの追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ jobs:
           - TZ: "Japan"
       - image: circleci/mysql:5.7
         environment:
+          - MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
           - MYSQL_USER: root
           - MYSQL_DB: ci_test
-          - MYAQL_PASSWORD: <%= Rails.application.credentials.development[:password] %>
     working_directory: ~/repo
     steps:
       # CI環境上の working_directory の値の場所にGitリポジトリをコピーする。
@@ -61,6 +61,8 @@ jobs:
       - run:
           name: Database Setup
           command: |
+            rm ./config/database.yml
+            mv ./config/database.yml.ci ./config/database.yml
             bundle exec rake db:create
             bundle exec rake db:schema:load
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
           - TZ: "Japan"
       - image: circleci/mysql:5.7
         environment:
-          - MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
           - MYSQL_USER: root
           - MYSQL_DB: ci_test
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
         environment:
           - MYSQL_USER: root
           - MYSQL_DB: ci_test
+          - MYAQL_PASSWORD: <%= Rails.application.credentials.development[:password] %>
     working_directory: ~/repo
     steps:
       # CI環境上の working_directory の値の場所にGitリポジトリをコピーする。

--- a/app/controllers/account_books_controller.rb
+++ b/app/controllers/account_books_controller.rb
@@ -11,7 +11,7 @@ class AccountBooksController < ApplicationController
 
   # my家計簿の表示
   def show
-    @account_book = AccountBook.find_by(user_id: current_user.id)
+    @account_book = current_user.account_book
     @expenses_for_graph = @account_book.expenses.order_by_expense_item_group
     @expenses = @account_book.expenses.includes(:expense_item).order(expenditure: :desc)
     @user_profile = UserProfile.find_by(user_id: current_user.id)

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@ test:
   <<: *default
   database: ci_test
   host: <%=ENV['DB_HOST'] || '127.0.0.1' %>
-  password: ""
+  password: <%= Rails.application.credentials.development[:password] %>
 
 production:
   <<: *default

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,0 +1,29 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  charset: utf8mb4
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  host: localhost
+  collation: utf8mb4_bin
+
+development:
+  <<: *default
+  database: Sharing_Kakeibo_development
+  password: <%= Rails.application.credentials.development[:password] %>
+
+test:
+  <<: *default
+  database: ci_test
+  host: <%=ENV['DB_HOST'] || '127.0.0.1' %>
+  password: ""
+
+production:
+  <<: *default
+  database: Sharing_Kakeibo_production
+  username: <%= Rails.application.credentials.production[:username] %>
+  password: <%= Rails.application.credentials.production[:password] %>
+  host: <%= Rails.application.credentials.production[:host] %>
+  socket: /var/lib/mysql/mysql.sock
+  pool: 5
+  timeout: 5000


### PR DESCRIPTION
## 概要
① `account_books_controller.rb`のコードを修正
```
def show
    @account_book = AccountBook.find_by(user_id: current_user.id)

を以下のように修正しました
    @account_book = current_user.account_book
```




② CircleCIで使用する`database.yaml.ci`を作成し、CircleCI上ではこちらを使用するように変更しました。
開発環境とCI環境でpasswordが異なっておりました。（CI環境ではpw使用せず）
そのため、以前は開発環境だけで読み込めるように`gem 'dotenv'`を使用してパスワードを設定し、Github上にはそのパスワード環境変数をpushしないことでCI上にはパスワードが空になるようにしていたのですが、力技だったので、わかりやすいように修正しました。

- CI用の`database.yml.ci`を用意し、CIのコマンドでこちらのファイルを入れ替えて読み替えるようにしました。

```
      # DBのセットアップ
      - run:
          name: Database Setup
          command: |
            rm ./config/database.yml
            mv ./config/database.yml.ci ./config/database.yml
            bundle exec rake db:create
            bundle exec rake db:schema:load
```
https://study-diary.hatenadiary.jp/entry/2021/03/06/150833
技術ブログにもまとめました。